### PR TITLE
README: Fix Gitter chat SVG icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/debt_ceiling.svg)](http://badge.fury.io/rb/debt_ceiling)
 [![Build Status](https://travis-ci.org/bglusman/debt_ceiling.svg?branch=master)](https://travis-ci.org/bglusman/debt_ceiling)
 [![Coverage Status](https://img.shields.io/coveralls/bglusman/debt_ceiling.svg)](https://coveralls.io/r/bglusman/debt_ceiling?branch=master)
-[![Debt Ceiling Chat](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/bglusman/debt_ceiling)
+[![Debt Ceiling Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bglusman/debt_ceiling)
 [![Stories in Ready](https://badge.waffle.io/bglusman/debt_ceiling.png?label=ready&title=Ready)](https://waffle.io/bglusman/debt_ceiling)
 [![Code Climate](https://codeclimate.com/github/bglusman/debt_ceiling/badges/gpa.svg)](https://codeclimate.com/github/bglusman/debt_ceiling)
 #DebtCeiling


### PR DESCRIPTION
This fixes a Markdown image link to render as an icon.